### PR TITLE
clear statusloop interval before set it

### DIFF
--- a/index.js
+++ b/index.js
@@ -974,6 +974,7 @@ io.on("connection", function(socket) {
             io.sockets.emit('grbl')
           }, 600)
           // Start interval for status queries
+          clearInterval(statusLoop);
           statusLoop = setInterval(function() {
             if (status.comms.connectionStatus > 0) {
               addQRealtime("?");


### PR DESCRIPTION
Everytime grbl restarts, welcome message (with "Grbl" it) will trigger setting the statusloop, without clear the loop previously set. stopPort() only clear the last one, but leftover rest of them. Adding clearInterval right before setInterval to ensure single statusloop.

Forum conversation: https://openbuilds.com/threads/grbl-mega-or-mega-x5-not-recognised.15890/

Co-Authored-By: AqeeAqee <25360426+aqeeaqee@users.noreply.github.com>