### PR TITLE
Normalize `Surfacing / Flattening Wizard` output

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1330,7 +1330,7 @@
       </div>
 
       <div class="dialog dark" data-role="dialog" id="surfacingDialog" data-width="90%" data-actions-align="right" data-overlay-click-close="true">
-        <div class="dialog-title"><i class="fas fa-exchange-alt"></i> Flattening / Surfacing Tool</div>
+        <div class="dialog-title"><i class="fas fa-exchange-alt"></i> Surfacing / Flattening Wizard</div>
         <div class="dialog-content" style="max-height: calc(100vh - 100px);overflow-y: auto; overflow-x: hidden;">
           <form>
             <div class="row mb-2">
@@ -1393,12 +1393,12 @@
 
               </div>
               <div class="cell-sm-5">
-                <small class="text-muted">NB: make sure your spindle is 100% perpendicular (trammed) to your bed, before running a Surfacing operation. Incorrectly trammed spindles will cause uneven machining of the surface, leading to pitting and
+                <small class="text-muted">NB: make sure your spindle is 100% perpendicular (trammed) to your bed, before running a surfacing operation. Incorrectly trammed spindles will cause uneven machining of the surface, leading to pitting and
                   uneven surface finish
                 </small>
                 <hr>
 
-                <small class="text-muted">You can use the Surfacing Tool to
+                <small class="text-muted">You can use the Surfacing / Flattening Wizard to
                   <ul class="text-muted">
                     <li>Prepare / flatten your spoilboard</li>
                     <li>Level off stock</li>

--- a/app/wizards/surfacing/surfacing.js
+++ b/app/wizards/surfacing/surfacing.js
@@ -67,7 +67,7 @@ G54; Work Coordinates
 G21; mm-mode
 G90; Absolute Positioning
 M3 S` + data.surfaceRPM + `; Spindle On
-G4 P1.8 ; Wait for spindle to come up to speed
+G4 P1.8; Wait for spindle to come up to speed
 G0 Z10
 G0 X0 Y0
 G1 F` +

--- a/app/wizards/surfacing/surfacing.js
+++ b/app/wizards/surfacing/surfacing.js
@@ -150,7 +150,7 @@ G1 X` +
 
   editor.session.setValue(gcode);
   parseGcodeInWebWorker(gcode)
-  printLog("<span class='fg-red'>[ Surfacing Wizard ] </span><span class='fg-green'>GCODE Loaded</span>")
+  printLog("<span class='fg-red'>[ Surfacing / Flattening Wizard ] </span><span class='fg-green'>GCODE Loaded</span>")
 
   // console.log(gcode);
   //

--- a/app/wizards/surfacing/surfacing.js
+++ b/app/wizards/surfacing/surfacing.js
@@ -80,12 +80,12 @@ G1 F` +
       `G0 X` +
       startpointX +
       ` Y` +
-      startpointY +
+      startpointY.toFixed(4) +
       ` Z10\n
 G1 X` +
       startpointX +
       ` Y` +
-      startpointY +
+      startpointY.toFixed(4) +
       ` Z-` +
       data.surfaceDepth +
       `\n`;
@@ -94,12 +94,12 @@ G1 X` +
       `G0 X` +
       endpointX +
       ` Y` +
-      startpointY +
+      startpointY.toFixed(4) +
       ` Z10\n
 G1 X` +
       endpointX +
       ` Y` +
-      startpointY +
+      startpointY.toFixed(4) +
       ` Z-` +
       data.surfaceDepth +
       `\n`;
@@ -120,14 +120,14 @@ G1 X` +
   }
 
   if (!reverse) {
-    gcode += `G1 Y` + endpointY + `\n`;
-    gcode += `G1 X` + startpointX + ` Y` + endpointY + ` Z-` + data.surfaceDepth + `\n`;
-    gcode += `G1 X` + endpointX + ` Y` + endpointY + ` Z-` + data.surfaceDepth + `\n`;
+    gcode += `G1 Y` + endpointY.toFixed(4) + `\n`;
+    gcode += `G1 X` + startpointX + ` Y` + endpointY.toFixed(4) + ` Z-` + data.surfaceDepth + `\n`;
+    gcode += `G1 X` + endpointX + ` Y` + endpointY.toFixed(4) + ` Z-` + data.surfaceDepth + `\n`;
     reverse = true;
   } else {
-    gcode += `G1 Y` + endpointY + `\n`;
-    gcode += `G1 X` + endpointX + ` Y` + endpointY + ` Z-` + data.surfaceDepth + `\n`;
-    gcode += `G1 X` + startpointX + ` Y` + endpointY + ` Z-` + data.surfaceDepth + `\n`;
+    gcode += `G1 Y` + endpointY.toFixed(4) + `\n`;
+    gcode += `G1 X` + endpointX + ` Y` + endpointY.toFixed(4) + ` Z-` + data.surfaceDepth + `\n`;
+    gcode += `G1 X` + startpointX + ` Y` + endpointY.toFixed(4) + ` Z-` + data.surfaceDepth + `\n`;
     reverse = false;
   }
 
@@ -135,13 +135,13 @@ G1 X` +
 
   // Framing Pass
   gcode += `; Framing pass\n`;
-  gcode += `G0 X` + startpointX + ` Y` + startpointY + ` Z10\n`; // position at start point
+  gcode += `G0 X` + startpointX + ` Y` + startpointY.toFixed(4) + ` Z10\n`; // position at start point
   gcode += `G1 Z-` + data.surfaceDepth + `\n`; // plunge
-  gcode += `G1 X` + startpointX + ` Y` + endpointY + ` Z-` + data.surfaceDepth + `\n`; // Cut side
+  gcode += `G1 X` + startpointX + ` Y` + endpointY.toFixed(4) + ` Z-` + data.surfaceDepth + `\n`; // Cut side
   gcode += `G0 Z10\n`;
-  gcode += `G0 X` + endpointX + ` Y` + endpointY + `\n`; // position at start point
+  gcode += `G0 X` + endpointX + ` Y` + endpointY.toFixed(4) + `\n`; // position at start point
   gcode += `G1 Z-` + data.surfaceDepth + `\n`; // plunge
-  gcode += `G1 X` + endpointX + ` Y` + startpointY + ` Z-` + data.surfaceDepth + `\n`; // Cut side
+  gcode += `G1 X` + endpointX + ` Y` + startpointY.toFixed(4) + ` Z-` + data.surfaceDepth + `\n`; // Cut side
   gcode += `G0 Z10\n`;
   gcode += `G0 X0 Y0\n`;
 

--- a/app/wizards/surfacing/surfacing.js
+++ b/app/wizards/surfacing/surfacing.js
@@ -135,13 +135,13 @@ G1 X` +
 
   // Framing Pass
   gcode += `; Framing pass\n`;
-  gcode += `G0 X` + startpointX + ` Y` + startpointY + `Z10\n`; // position at start point
+  gcode += `G0 X` + startpointX + ` Y` + startpointY + ` Z10\n`; // position at start point
   gcode += `G1 Z-` + data.surfaceDepth + `\n`; // plunge
-  gcode += `G1 X` + startpointX + ` Y` + endpointY + `Z-` + data.surfaceDepth + `\n`; // Cut side
+  gcode += `G1 X` + startpointX + ` Y` + endpointY + ` Z-` + data.surfaceDepth + `\n`; // Cut side
   gcode += `G0 Z10\n`;
   gcode += `G0 X` + endpointX + ` Y` + endpointY + `\n`; // position at start point
   gcode += `G1 Z-` + data.surfaceDepth + `\n`; // plunge
-  gcode += `G1 X` + endpointX + ` Y` + startpointY + `Z-` + data.surfaceDepth + `\n`; // Cut side
+  gcode += `G1 X` + endpointX + ` Y` + startpointY + ` Z-` + data.surfaceDepth + `\n`; // Cut side
   gcode += `G0 Z10\n`;
   gcode += `G0 X0 Y0\n`;
 


### PR DESCRIPTION
While looking closely at the GCode output by the `Surfacing / Flattening Wizard`, I noticed some inconsistencies that I thought I'd correct:

* The comment on the `G4` has an extra space compared to the other comments in the file
* The `Z` parameter for the framing pass is missing a leading space
* The number of decimals printed for the Y parameter vary throughout the command
* The title of the wizard dialog box is the opposite of the order in the dropdown:
<img width="454" alt="image" src="https://user-images.githubusercontent.com/1459385/153316762-f4322b2e-b951-4e94-972c-209f1358d356.png">

<img width="317" alt="image" src="https://user-images.githubusercontent.com/1459385/153316789-230db9d0-86a1-4470-bb4f-dfc737dd47b8.png">

---

This PR makes the small adjustments to make everything consistent ✨

Note: I never ran the code to make sure the changes worked as expected.