### PR TITLE
Changed first xy move to G0 to avoid laser on issues

### DIFF
--- a/app/wizards/resume/resume.js
+++ b/app/wizards/resume/resume.js
@@ -128,7 +128,7 @@ function startFromHere(lineNumber) {
     }
   }
 
-  var GcodeLineXYA = "G1" + lineX + lineY + lineA + lineFmax
+  var GcodeLineXYA = "G0" + lineX + lineY + lineA + lineFmax
   var GcodeLineZDown = "G1" + lineZm + lineFmin
 
   var resumeFileTemplate = `


### PR DESCRIPTION
As discuss here:

Lasers need a G0 move into position.  I believe this simple change should do it and not adversely affect routers since the first move is a z clearance move.