### PR TITLE
Exclude parameter descriptions when parsing grbl settings

### DIFF
--- a/app/js/grbl-settings.js
+++ b/app/js/grbl-settings.js
@@ -74,7 +74,12 @@ function grblSettings(data) {
   grblconfig = data.split('\n')
   for (i = 0; i < grblconfig.length; i++) {
     var key = grblconfig[i].split('=')[0];
-    var param = grblconfig[i].split('=')[1]
+    // Certain versions of grbl add a description to each parameter returned by the '$$'
+    // command. Use parseFloat to get just the numerical value. 
+    // For example:
+    // $0=10 (step pulse,usec) ;Step pulse time, microseconds
+    // would convert to just 10 rather than '10 (step pulse,usec)'
+    var param = parseFloat(grblconfig[i].split('=')[1]);
     grblParams[key] = param
   }
   // $('#grblconfig').show();


### PR DESCRIPTION
While setting up a new machine (Sainsmart Genmitsu 4040) I was having issues getting the machine settings to be recognized. It always thought that it had setting changes to save. Additionally the home and jog features were not working.

After a bit of debugging I found out the issue was because the `$$` gcode command on my machine was reporting each setting with a description in parentheses added onto the end. The machine is running GRBL 1.1f where I wouldn't expect the descriptions to still be printed from the `$$` command... but they are.

This PR updates the grbl settings parsing logic so it will sanitize each parameter value using `parseFloat` so that any of the descriptions are ignored.