### PR TITLE
Dark mode fixes for new mm/in dropdown on probe screen.  Added ability to save / remember last endmill diameter

### DIFF
--- a/app/css/themes/dark.css
+++ b/app/css/themes/dark.css
@@ -102,6 +102,14 @@ body.theme_dark, .theme_dark div.window, .theme_dark .card {
   color: #FFF;
 }
 
+.theme_dark .dropdown-toggle:not(.success) {
+  border: 1px solid #555;
+}
+
+.theme_dark .dropdown-toggle::before {
+  border-color: #FFF;
+}
+
 .theme_dark .file.disabled .caption, .theme_dark .file.disabled .select-input, .theme_dark .file.disabled .stars li, .theme_dark .file.disabled input, .theme_dark .file.disabled select, .theme_dark .file.disabled textarea, .theme_dark .file:disabled .caption, .theme_dark .file:disabled .select-input, .theme_dark .file:disabled .stars li, .theme_dark .file:disabled input, .theme_dark .file:disabled select, .theme_dark .file:disabled textarea, .theme_dark .input.disabled .caption, .theme_dark .input.disabled .select-input, .theme_dark .input.disabled .stars li, .theme_dark .input.disabled input, .theme_dark .input.disabled select, .theme_dark .input.disabled textarea, .theme_dark .input:disabled .caption, .theme_dark .input:disabled .select-input, .theme_dark .input:disabled .stars li, .theme_dark .input:disabled input, .theme_dark .input:disabled select, .theme_dark .input:disabled textarea, .theme_dark .rating.disabled .caption, .theme_dark .rating.disabled .select-input, .theme_dark .rating.disabled .stars li, .theme_dark .rating.disabled input, .theme_dark .rating.disabled select, .theme_dark .rating.disabled textarea, .theme_dark .rating:disabled .caption, .theme_dark .rating:disabled .select-input, .theme_dark .rating:disabled .stars li, .theme_dark .rating:disabled input, .theme_dark .rating:disabled select, .theme_dark .rating:disabled textarea, .theme_dark .select.disabled .caption, .theme_dark .select.disabled .select-input, .theme_dark .select.disabled .stars li, .theme_dark .select.disabled input, .theme_dark .select.disabled select, .theme_dark .select.disabled textarea, .theme_dark .select:disabled .caption, .theme_dark .select:disabled .select-input, .theme_dark .select:disabled .stars li, .theme_dark .select:disabled input, .theme_dark .select:disabled select, .theme_dark .select:disabled textarea, .theme_dark .spinner.disabled .caption, .theme_dark .spinner.disabled .select-input, .theme_dark .spinner.disabled .stars li, .theme_dark .spinner.disabled input, .theme_dark .spinner.disabled select, .theme_dark .spinner.disabled textarea, .theme_dark .spinner:disabled .caption, .theme_dark .spinner:disabled .select-input, .theme_dark .spinner:disabled .stars li, .theme_dark .spinner:disabled input, .theme_dark .spinner:disabled select, .theme_dark .spinner:disabled textarea, .theme_dark .tag-input.disabled .caption, .theme_dark .tag-input.disabled .select-input, .theme_dark .tag-input.disabled .stars li, .theme_dark .tag-input.disabled input, .theme_dark .tag-input.disabled select, .theme_dark .tag-input.disabled textarea, .theme_dark .tag-input:disabled .caption, .theme_dark .tag-input:disabled .select-input, .theme_dark .tag-input:disabled .stars li, .theme_dark .tag-input:disabled input, .theme_dark .tag-input:disabled select, .theme_dark .tag-input:disabled textarea, .theme_dark .textarea.disabled .caption, .theme_dark .textarea.disabled .select-input, .theme_dark .textarea.disabled .stars li, .theme_dark .textarea.disabled input, .theme_dark .textarea.disabled select, .theme_dark .textarea.disabled textarea, .theme_dark .textarea:disabled .caption, .theme_dark .textarea:disabled .select-input, .theme_dark .textarea:disabled .stars li, .theme_dark .textarea:disabled input, .theme_dark .textarea:disabled select, .theme_dark .textarea:disabled textarea {
   background-color: #222;
   color: #666;
@@ -400,7 +408,7 @@ body.theme_dark, .theme_dark div.window, .theme_dark .card {
   border: 1px solid #ce352c;
 }
 
-.theme_dark select {
+.theme_dark select  {
   border: 1px solid #555;
 }
 

--- a/app/wizards/probe/probev2.js
+++ b/app/wizards/probe/probev2.js
@@ -46,6 +46,16 @@ $(document).ready(function() {
   if (localStorage.getItem('z0platethickness')) {
     zprobeplate.zoffset = localStorage.getItem('z0platethickness')
   }
+
+  if (localStorage.getItem('probediameterxyz')) {
+    probediameterxyz = localStorage.getItem('probediameterxyz')
+    $("#probediameterxyz").val(probediameterxyz)
+  }
+
+  if (localStorage.getItem('probeunitxyz')) {
+    probeunitxyz = localStorage.getItem('probeunitxyz')
+    $('#probeunitxyz').data('select').val(probeunitxyz)  
+  }
 });
 
 if (localStorage.getItem('customProbe')) {
@@ -55,6 +65,14 @@ if (localStorage.getItem('customProbe')) {
 $("#z0platethickness").keyup(function() {
   localStorage.setItem('z0platethickness', $("#z0platethickness").val())
   zprobeplate.zoffset = $("#z0platethickness").val()
+});
+
+$("#probediameterxyz").keyup(function() {
+  localStorage.setItem('probediameterxyz', $("#probediameterxyz").val())
+});
+
+$("#probeunitxyz").change(function() {
+  localStorage.setItem('probeunitxyz', $("#probeunitxyz").val())
 });
 
 


### PR DESCRIPTION
The new mm /  inch dropdown on the probe screen had a white boarder and you couldnt see the dropdown icon in dark mode.

Both the endmill diameter and endmill unit are saved to localstorage on change and recalled when probe form is opened.