### PR TITLE
Handle Jog parameters stored as strings

### DIFF
--- a/app/js/grbl-settings-templates.js
+++ b/app/js/grbl-settings-templates.js
@@ -130,8 +130,8 @@ var grblSettingsTemplate2 = {
     title: `Report in inches, boolean`,
     description: `Grbl has a real-time positioning reporting feature to provide a user feedback on where the machine is exactly at that time, as well as, parameters for coordinate offsets and probing. By default, it is set to report in mm, but by sending a $13=1 command, you send this boolean flag to true and these reporting features will now report in inches. $13=0 to set back to mm.`,
     template: `<select id="val-13-input">
-             <option value="0">&#9898; Disable</option>
-             <option value="1">&#9899; Enable</option>
+             <option value="0">&#x2717; Disable</option>
+             <option value="1">&#x2713; Enable</option>
           </select>`,
     utils: ``
   },

--- a/app/js/grbl-settings.js
+++ b/app/js/grbl-settings.js
@@ -592,7 +592,8 @@ function setup_settings_table() {
     $("#val-2-input").val(parseInt(grblParams['$2'])).trigger("change");
     $("#val-3-input").val(parseInt(grblParams['$3'])).trigger("change");
     $("#val-4-input").val(parseInt(grblParams['$4'])).trigger("change");
-  }, 100);;
+    $("#val-13-input").val(parseInt(grblParams['$13'])).trigger("change");
+  }, 100);
 
   $('#xdirinvert:checkbox').change(function() {
     changeDirInvert();

--- a/app/js/jog.js
+++ b/app/js/jog.js
@@ -10,14 +10,14 @@ var jogRateA = 2000
 
 function jogOverride(newVal) {
   if (grblParams.hasOwnProperty('$110')) {
-    jogRateX = (grblParams['$110'] * (newVal / 100)).toFixed(0);
-    jogRateY = (grblParams['$111'] * (newVal / 100)).toFixed(0);
-    jogRateZ = (grblParams['$112'] * (newVal / 100)).toFixed(0);
+    jogRateX = (parseInt(grblParams['$110']) * (newVal / 100)).toFixed(0);
+    jogRateY = (parseInt(grblParams['$111']) * (newVal / 100)).toFixed(0);
+    jogRateZ = (parseInt(grblParams['$112']) * (newVal / 100)).toFixed(0);
 
     $('#jro').data('slider').val(newVal)
   }
   if (grblParams.hasOwnProperty('$113')) {
-    jogRateA = (grblParams['$113'] * (newVal / 100)).toFixed(0);
+    jogRateA = (parseInt(grblParams['$113']) * (newVal / 100)).toFixed(0);
   }
   localStorage.setItem('jogOverride', newVal);
 }


### PR DESCRIPTION
I am unable to use the jog dials on my Genmitsu 4040-Pro as the GRBL Params for $110, $111, and $112  (+ $113) are stored as strings. The fix is to perform a parseInt() on the param, which will work if int or string. This resolves the issue.