### PR TITLE
Remove noise from GRBL param response

### DIFF
--- a/app/js/grbl-settings.js
+++ b/app/js/grbl-settings.js
@@ -73,7 +73,7 @@ function grblSettings(data) {
   grblconfig = data.split('\n')
   for (i = 0; i < grblconfig.length; i++) {
     var key = grblconfig[i].split('=')[0];
-    var param = grblconfig[i].split('=')[1]
+    var param = grblconfig[i].split(/[= ;(]/)[1]
     grblParams[key] = param
   }
   // $('#grblconfig').show();


### PR DESCRIPTION
My Genmitsu 4040-Pro returns the "title" with the parameter value and that title value is carried throughout, breaking some parts of the code/functionality. For example, Jog does not work: incremental does nothing and continuous produces a NaN value resulting in an error.

A small sample of the response from my machine follows.
```
[10:04:25] [ ] Grbl 1.1f ['$' for help]
[10:04:25] [ ] Grbl for ARM32
[10:04:25] [ ] Version:ARM32 V3.0
[10:04:25] [ ] $0=10 (step pulse,usec) ;Step pulse time, microseconds
[10:04:25] [ ] $1=25 (step idle delay,msec) ;Step idle delay, milliseconds
[10:04:25] [ ] $2=0 (stepport invert mask) ;Step pulse invert, mask
[10:04:25] [ ] $3=4 (dirport invert mask) ;Step direction invert, mask
[10:04:25] [ ] $4=0 (stepenable invert,bool) ;Invert step enable pin, boolean
[10:04:25] [ ] $5=1 (lims pin invert,bool) ;Invert limit pins, boolean/mask
```
Note the information after the value - this is the part that is carried throughout the code and causes issues when that value is expected to be an integer or a float (as a string or the actual type). 

On reading the value back from GRBL, if I remove the "noise", everything works well. This is a much better solution than my earlier proposed solution, #365.

Thank you so much for all your support!