### PR TITLE
Fix #401: Add reload last file functionality

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -361,6 +361,16 @@
                   </ul>
                 </div>
 
+                <div>
+                  <!-- Used in Electron only -->
+                  <button id="reloadGcodeBtnElectron19" class="ribbon-button" title="Reload the current GCODE file from disk" onclick="socket.emit('reloadFile')" disabled>
+                    <span class="icon">
+                      <i id="reloadIcon" class="fas fa-sync-alt fg-gray"></i>
+                    </span>
+                    <span class="caption">Reload<br>G-CODE</span>
+                  </button>
+                </div>
+
                 <span class="title">File</span>
               </div>
 
@@ -1907,7 +1917,7 @@
   <script type="text/javascript" src="js/viewer.js"></script>
   <script type="text/javascript" src="js/viewer-ruler.js"></script>
 
-  <script type="text/javascript" src="js/main.js"></script>
+    <script type="text/javascript" src="js/main.js"></script>
   <script type="text/javascript" src="js/updates.js"></script>
   <script type="text/javascript" src="js/ui.js"></script>
 

--- a/app/index.html
+++ b/app/index.html
@@ -1917,7 +1917,7 @@
   <script type="text/javascript" src="js/viewer.js"></script>
   <script type="text/javascript" src="js/viewer-ruler.js"></script>
 
-    <script type="text/javascript" src="js/main.js"></script>
+  <script type="text/javascript" src="js/main.js"></script>
   <script type="text/javascript" src="js/updates.js"></script>
   <script type="text/javascript" src="js/ui.js"></script>
 

--- a/app/js/filemanager.js
+++ b/app/js/filemanager.js
@@ -1,0 +1,28 @@
+const { EventEmitter } = require('events');
+
+class FileManager extends EventEmitter { 
+    constructor() {
+        super();
+        this._lastFilePath = "";
+    }
+
+    get lastFilePath() {
+        return this._lastFilePath;
+    }
+
+    set lastFilePath(path) {
+        this._lastFilePath = path;
+        this.raiseLastFilePathChangedEvent();
+    }
+
+    clear(){
+        this._lastFilePath = "";
+        this.raiseLastFilePathChangedEvent();
+    }
+
+    raiseLastFilePathChangedEvent() {
+        this.emit('lastFilePathChangedEvent', this._lastFilePath);
+    }
+}
+
+module.exports = new FileManager();

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -113,10 +113,12 @@ $(document).ready(function() {
     console.log("Native Dialog Button Enabled")
     $("#openGcodeBtn").hide()
     $("#openGcodeBtnElectron19").show()
+    $("#reloadGcodeBtnElectron19").show()
   } else {
     console.log("Native Dialog Button Disabled")
     $("#openGcodeBtn").show()
     $("#openGcodeBtnElectron19").hide()
+    $("#reloadGcodeBtnElectron19").hide()
   }
 
 

--- a/app/js/websocket.js
+++ b/app/js/websocket.js
@@ -154,6 +154,18 @@ function initSocket() {
     }
   })
 
+  socket.on('lastFilePathChangedEvent', function(data) {
+    console.log('File path changed:', data);
+    
+    if (data.filePath) {
+      $("#reloadGcodeBtnElectron19").prop("disabled", false);
+      $("#reloadIcon").removeClass("fg-gray").addClass("fg-amber");
+    } else {
+      $("#reloadGcodeBtnElectron19").prop("disabled", true);
+      $("#reloadIcon").removeClass("fg-amber").addClass("fg-gray");
+    }
+  });
+
   socket.on('gcodeupload', function(data) {
     var icon = ''
     var source = "api"
@@ -179,7 +191,9 @@ function initSocket() {
     } else {
       $('#gcodeeditortab').click()
     }
-    jobNeedsHoming();
+    if(!data.isReload) { // on reload don't mention homing
+      jobNeedsHoming();
+    }
   });
 
   socket.on('gcodeupload', function(data) {

--- a/index.js
+++ b/index.js
@@ -62,6 +62,13 @@ config.posDecimals = process.env.DRO_DECIMALS || 3;
 config.grblWaitTime = 0.5;
 
 
+const fileManager = require('./app/js/fileManager');
+fileManager.on('lastFilePathChangedEvent', function(filePath) {
+  io.sockets.emit('lastFilePathChangedEvent', { 
+    filePath: filePath 
+  });
+});
+
 var express = require("express");
 var app = express();
 var http = require("http").Server(app);
@@ -721,6 +728,11 @@ io.on("connection", function(socket) {
       console.log(err)
     })
   })
+
+  socket.on("reloadFile", function(data) {
+    var lastFilePath= fileManager.lastFilePath; 
+    readFile(lastFilePath, true);
+  });
 
   socket.on("openInterfaceDir", function(data) {
     dialog.showOpenDialog(jogWindow, {
@@ -2231,7 +2243,7 @@ io.on("connection", function(socket) {
 
 });
 
-function readFile(filePath) {
+function readFile(filePath, isReload=false) {
   if (filePath) {
     if (filePath.length > 1) {
       var filename = path.parse(filePath)
@@ -2245,9 +2257,11 @@ function readFile(filePath) {
               'command': '',
               'response': "ERROR: File Upload Failed"
             }
+            fileManager.lastFilePath = "";
             uploadedgcode = "";
           }
           if (data) {
+            fileManager.lastFilePath = filePath;
             if (filePath.endsWith('.obc')) { // OpenBuildsCAM Workspace
               uploadedworkspace = data;
               const {
@@ -2257,8 +2271,8 @@ function readFile(filePath) {
             } else { // GCODE
               var payload = {
                 gcode: data,
-                filename: filename
-              }
+                filename: filename,
+                isReload: isReload,           }
               io.sockets.emit('gcodeupload', payload);
               uploadedgcode = data;
               return data


### PR DESCRIPTION
## Description
Adds a reload button to the GCODE interface that allows users to reload the currently loaded GCODE file. The button is only enabled when a file is actively loaded, preventing errors from attempting to reload when no file exists.

## Changes
- Added "Reload G-CODE" button to the ribbon interface
- Added visual feedback: button changes from gray (disabled) to amber (enabled)
- Added filemanager.js to keep track of last loaded filepath and raise event when changed

## Notes
This is my first contribution to an Electron/Node.js project. I've followed the existing code patterns and conventions used in the project. Please let me know if there are any improvements or changes needed to better align with the project's standards.
